### PR TITLE
Actions and reducers for data resets

### DIFF
--- a/src/actions/history.actions/index.js
+++ b/src/actions/history.actions/index.js
@@ -1,0 +1,7 @@
+import {
+  RESET_TIME_HISTORY,
+} from '../../constants/action-types';
+
+export function resetTimeHistory() {
+  return dispatch => dispatch({ type: RESET_TIME_HISTORY });
+}

--- a/src/actions/history.actions/test.js
+++ b/src/actions/history.actions/test.js
@@ -1,0 +1,27 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as types from '../../constants/action-types';
+import * as historyActions from './index';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+let store;
+
+describe('history actions', () => {
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  it('should exist', () => {
+    expect(historyActions).toBeDefined();
+  });
+
+  describe('resetTimeHistory', () => {
+    it('should dispatch properly', () => {
+      store.dispatch(historyActions.resetTimeHistory());
+      const actions = store.getActions();
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(types.RESET_TIME_HISTORY);
+    });
+  });
+});

--- a/src/actions/time.actions/index.js
+++ b/src/actions/time.actions/index.js
@@ -1,4 +1,5 @@
 import {
+  RESET_TIME,
   UNDO_UPDATE_TIME,
   UPDATE_TIME,
 } from '../../constants/action-types';
@@ -21,5 +22,11 @@ export function updateTime(ms) {
 
     dispatch({ type: UPDATE_TIME, ms });
     return updateTimers(dispatch, ms, lastMs);
+  };
+}
+
+export function resetTime() {
+  return (dispatch) => {
+    dispatch({ type: RESET_TIME });
   };
 }

--- a/src/actions/time.actions/test.js
+++ b/src/actions/time.actions/test.js
@@ -36,4 +36,13 @@ describe('time actions', () => {
       expect(actions[1].type).toBe(types.UPDATE_TIMERS);
     });
   });
+
+  describe('resetTime', () => {
+    it('should dispatch properly', () => {
+      store.dispatch(timeActions.resetTime());
+      const actions = store.getActions();
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(types.RESET_TIME);
+    });
+  });
 });

--- a/src/actions/timer.actions/index.js
+++ b/src/actions/timer.actions/index.js
@@ -1,6 +1,7 @@
 import {
   ADD_TIMER,
   REMOVE_TIMER,
+  REMOVE_ALL_TIMERS,
   UPDATE_TIMERS,
 } from '../../constants/action-types';
 
@@ -14,6 +15,10 @@ export function addTimer(timer) {
     dispatch({ type: ADD_TIMER, timer, ms });
     return updateTimers(dispatch, ms);
   };
+}
+
+export function removeAllTimers() {
+  return dispatch => dispatch({ type: REMOVE_ALL_TIMERS });
 }
 
 export function removeTimer(index) {

--- a/src/actions/timer.actions/test.js
+++ b/src/actions/timer.actions/test.js
@@ -37,6 +37,15 @@ describe('timer actions', () => {
     });
   });
 
+  describe('removeAllTimers', () => {
+    it('should dispatch properly', () => {
+      store.dispatch(timerActions.removeAllTimers());
+      const actions = store.getActions();
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(types.REMOVE_ALL_TIMERS);
+    });
+  });
+
   describe('updateTimers', () => {
     it('should dispatch properly', () => {
       store.dispatch(dispatch => timerActions.updateTimers(dispatch, 1));

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -1,6 +1,10 @@
+export const RESET_TIME = 'RESET_TIME';
 export const UPDATE_TIME = 'UPDATE_TIME';
 export const UNDO_UPDATE_TIME = 'UNDO_UPDATE_TIME';
 
 export const ADD_TIMER = 'ADD_TIMER';
 export const REMOVE_TIMER = 'REMOVE_TIMER';
+export const REMOVE_ALL_TIMERS = 'REMOVE_ALL_TIMERS';
 export const UPDATE_TIMERS = 'UPDATE_TIMERS';
+
+export const RESET_TIME_HISTORY = 'RESET_TIME_HISTORY';

--- a/src/reducers/time.reducer/index.js
+++ b/src/reducers/time.reducer/index.js
@@ -1,6 +1,8 @@
 import {
   UNDO_UPDATE_TIME,
   UPDATE_TIME,
+  RESET_TIME,
+  RESET_TIME_HISTORY,
 } from '../../constants/action-types';
 import { buildTimeUI } from '../../utils/index';
 
@@ -73,6 +75,24 @@ export default function timeReducer(state = timeKeeperState || initialState, act
         history,
       }));
       return newState;
+    }
+
+    case RESET_TIME: {
+      return Object.assign({}, state, {
+        ms: 0,
+        days: 1,
+        hours: '12',
+        minutes: '00',
+        seconds: '00',
+        sky: 'night',
+        rotation: -540,
+      });
+    }
+
+    case RESET_TIME_HISTORY: {
+      return Object.assign({}, state, {
+        history: [],
+      });
     }
 
     default:

--- a/src/reducers/time.reducer/test.js
+++ b/src/reducers/time.reducer/test.js
@@ -1,6 +1,8 @@
 import {
   UNDO_UPDATE_TIME,
   UPDATE_TIME,
+  RESET_TIME,
+  RESET_TIME_HISTORY,
 } from '../../constants/action-types';
 import reducer from './index';
 
@@ -89,6 +91,40 @@ describe('time reducer', () => {
         sky: 'night',
         rotation: -540,
         history: [0],
+      });
+    });
+
+    it('should handle RESET_TIME', () => {
+      expect(
+        reducer(state, {
+          type: RESET_TIME,
+        }),
+      ).toEqual({
+        ms: 0,
+        days: 1,
+        hours: '12',
+        minutes: '00',
+        seconds: '00',
+        sky: 'night',
+        rotation: -540,
+        history: [0, 1000],
+      });
+    });
+
+    it('should handle RESET_TIME_HISTORY', () => {
+      expect(
+        reducer(state, {
+          type: RESET_TIME_HISTORY,
+        }),
+      ).toEqual({
+        ms: 1000,
+        days: 1,
+        hours: '12',
+        minutes: '00',
+        seconds: '01',
+        sky: 'night',
+        rotation: -540,
+        history: [],
       });
     });
   });

--- a/src/reducers/timers.reducer/index.js
+++ b/src/reducers/timers.reducer/index.js
@@ -3,6 +3,7 @@ import { cloneDeep, filter, findIndex, isUndefined, sortedIndexBy } from 'lodash
 import {
   ADD_TIMER,
   REMOVE_TIMER,
+  REMOVE_ALL_TIMERS,
   UPDATE_TIMERS,
 } from '../../constants/action-types';
 
@@ -33,6 +34,10 @@ export default function timeReducer(state = initialState, action) {
         active: state.active,
         expired: state.expired,
       });
+    }
+
+    case REMOVE_ALL_TIMERS: {
+      return Object.assign({}, state, initialState);
     }
 
     case REMOVE_TIMER: {


### PR DESCRIPTION
## Description
- Actions and reducer for reset time, remove all timers, and reset time history

## Motivation and Context
- This is required to be able to delete the undo history, remove existing timers, and reset time to start.

## Types of changes
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added a screenshot if appropriate.
- Tested in
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge
