### PR TITLE
persist timers in local storage

### DIFF
--- a/src/actions/app/app.actions.js
+++ b/src/actions/app/app.actions.js
@@ -2,10 +2,12 @@ import { last } from 'lodash';
 
 import { getInitialHistoryStateFromLocalStorage } from '../../utils/local-storage/local-storage';
 import { setTime } from '../../actions/time/time.actions';
+import { setTimers } from '../../actions/timers/timers.actions';
 
 export function bootstrap() {
   return (dispatch) => {
     const history = getInitialHistoryStateFromLocalStorage();
+    dispatch(setTimers(history.timers));
     dispatch(setTime(last(history.time)));
   };
 }

--- a/src/actions/app/app.actions.test.js
+++ b/src/actions/app/app.actions.test.js
@@ -26,6 +26,10 @@ describe('app actions', () => {
       const actions = store.getActions();
       expect(actions).toEqual([
         {
+          timers: [],
+          type: types.SET_TIMERS,
+        },
+        {
           ms: 0,
           type: types.UPDATE_TIMEKEEPER,
         },

--- a/src/actions/timers/timers.actions.js
+++ b/src/actions/timers/timers.actions.js
@@ -2,8 +2,13 @@ import {
   ADD_TIMER,
   REMOVE_TIMER,
   REMOVE_ALL_TIMERS,
+  SET_TIMERS,
   UPDATE_TIMERS,
 } from '../../constants/action-types';
+
+export function setTimers(timers) {
+  return dispatch => dispatch({ type: SET_TIMERS, timers });
+}
 
 export function updateTimers(dispatch, ms, lastMs) {
   return dispatch({ type: UPDATE_TIMERS, ms, lastMs });

--- a/src/actions/timers/timers.actions.test.js
+++ b/src/actions/timers/timers.actions.test.js
@@ -46,6 +46,15 @@ describe('timer actions', () => {
     });
   });
 
+  describe('setTimers', () => {
+    it('should dispatch properly', () => {
+      store.dispatch(timerActions.setTimers());
+      const actions = store.getActions();
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(types.SET_TIMERS);
+    });
+  });
+
   describe('updateTimers', () => {
     it('should dispatch properly', () => {
       store.dispatch(dispatch => timerActions.updateTimers(dispatch, 1));

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -10,4 +10,5 @@ export const UPDATE_TIMEKEEPER = 'UPDATE_TIMEKEEPER';
 export const ADD_TIMER = 'ADD_TIMER';
 export const REMOVE_TIMER = 'REMOVE_TIMER';
 export const REMOVE_ALL_TIMERS = 'REMOVE_ALL_TIMERS';
+export const SET_TIMERS = 'SET_TIMERS';
 export const UPDATE_TIMERS = 'UPDATE_TIMERS';

--- a/src/reducers/history/history.reducer.js
+++ b/src/reducers/history/history.reducer.js
@@ -3,11 +3,14 @@ import {
   UPDATE_TIME_HISTORY,
   UNDO_UPDATE_TIME_HISTORY,
   RESET_TIME_HISTORY,
+  ADD_TIMER,
 } from '../../constants/action-types';
+import { createNewTimer, insertTimer } from '../timers/timers.utils';
 import { getInitialHistoryStateFromLocalStorage, updateLocalStorage } from '../../utils/local-storage/local-storage';
 
 const initialState = {
   time: [0],
+  timers: [],
 };
 
 const localStorageData = getInitialHistoryStateFromLocalStorage();
@@ -43,6 +46,18 @@ export default function timeReducer(state = localStorageData || initialState, ac
     case RESET_TIME_HISTORY: {
       const newState = Object.assign({}, state, {
         time: [action.ms],
+      });
+
+      updateLocalStorage({ [config.localStorage.history]: { ...newState } });
+      return newState;
+    }
+
+    case ADD_TIMER: {
+      const timer = createNewTimer(action.timer, action.ms);
+      const timers = insertTimer(state.timers, timer);
+
+      const newState = Object.assign({}, state, {
+        timers,
       });
 
       updateLocalStorage({ [config.localStorage.history]: { ...newState } });

--- a/src/reducers/history/history.reducer.test.js
+++ b/src/reducers/history/history.reducer.test.js
@@ -3,6 +3,7 @@ import reducer from './history.reducer';
 
 const initialState = {
   time: [0],
+  timers: [],
 };
 
 describe('history reducer', () => {
@@ -29,6 +30,7 @@ describe('history reducer', () => {
         ms: 1000,
       })).toEqual({
         time: [0, 1000],
+        timers: [],
       });
     });
 
@@ -37,6 +39,7 @@ describe('history reducer', () => {
         type: types.UNDO_UPDATE_TIME_HISTORY,
       })).toEqual({
         time: [0],
+        timers: [],
       });
     });
 
@@ -46,34 +49,51 @@ describe('history reducer', () => {
         ms: 1000,
       })).toEqual({
         time: [1000],
+        timers: [],
       });
     });
   });
 
   describe('when state exists', () => {
     it('should handle UPDATE_TIME_HISTORY', () => {
-      expect(reducer({ time: [0, 1, 2] }, {
+      expect(reducer({ time: [0, 1, 2], timers: [] }, {
         type: types.UPDATE_TIME_HISTORY,
         ms: 1000,
       })).toEqual({
         time: [0, 1, 2, 1000],
+        timers: [],
       });
     });
 
     it('should handle UNDO_UPDATE_TIME_HISTORY', () => {
-      expect(reducer({ time: [0, 1, 2] }, {
+      expect(reducer({ time: [0, 1, 2], timers: [] }, {
         type: types.UNDO_UPDATE_TIME_HISTORY,
       })).toEqual({
         time: [0, 1],
+        timers: [],
       });
     });
 
     it('should handle RESET_TIME_HISTORY', () => {
-      expect(reducer({ time: [0, 1, 2] }, {
+      expect(reducer({ time: [0, 1, 2], timers: [] }, {
         type: types.RESET_TIME_HISTORY,
         ms: 1000,
       })).toEqual({
         time: [1000],
+        timers: [],
+      });
+    });
+
+    it('should handle ADD_TIMER', () => {
+      expect(
+        reducer(initialState, {
+          type: types.ADD_TIMER,
+          timer: { ms: 1, text: 'foo' },
+          ms: 2,
+        }),
+      ).toEqual({
+        time: [0],
+        timers: [{ ms: 3, text: 'foo' }],
       });
     });
   });

--- a/src/reducers/timers/timers.reducer.js
+++ b/src/reducers/timers/timers.reducer.js
@@ -1,9 +1,11 @@
-import { cloneDeep, filter, findIndex, isUndefined, sortedIndexBy } from 'lodash';
+import { cloneDeep, filter, findIndex, isUndefined } from 'lodash';
+import { createNewTimer, insertTimer } from './timers.utils';
 
 import {
   ADD_TIMER,
   REMOVE_TIMER,
   REMOVE_ALL_TIMERS,
+  SET_TIMERS,
   UPDATE_TIMERS,
 } from '../../constants/action-types';
 
@@ -17,17 +19,8 @@ const initialState = {
 export default function timeReducer(state = initialState, action) {
   switch (action.type) {
     case ADD_TIMER: {
-      const newTimer = cloneDeep(action.timer);
-      newTimer.ms = action.timer.ms + action.ms;
-
-      // find index to insert new timer
-      const index = sortedIndexBy(state.timers, newTimer, 'ms');
-
-      const timers = [
-        ...state.timers.slice(0, index),
-        newTimer,
-        ...state.timers.slice(index),
-      ];
+      const timer = createNewTimer(action.timer, action.ms);
+      const timers = insertTimer(state.timers, timer);
 
       return Object.assign({}, state, {
         timers,
@@ -48,6 +41,12 @@ export default function timeReducer(state = initialState, action) {
         ],
         active: state.active,
         expired: state.expired,
+      });
+    }
+
+    case SET_TIMERS: {
+      return Object.assign({}, state, {
+        timers: action.timers,
       });
     }
 

--- a/src/reducers/timers/timers.utils.js
+++ b/src/reducers/timers/timers.utils.js
@@ -1,0 +1,32 @@
+// @flow
+
+import { cloneDeep, sortedIndexBy } from 'lodash';
+
+export function createNewTimer(timer: {
+  ms: number,
+  text: string,
+}, ms: number) {
+  const newTimer = cloneDeep(timer);
+  newTimer.ms = timer.ms + ms;
+
+  return newTimer;
+}
+
+export function insertTimer(timers: [
+  {
+    ms: number,
+    text: string,
+  },
+], timer: {
+  ms: number,
+  text: string,
+}) {
+  // find index to insert new timer
+  const index = sortedIndexBy(timers, timer, 'ms');
+
+  return [
+    ...timers.slice(0, index),
+    timer,
+    ...timers.slice(index),
+  ];
+}

--- a/src/reducers/timers/timers.utils.test.js
+++ b/src/reducers/timers/timers.utils.test.js
@@ -1,0 +1,37 @@
+import * as timersUtils from './timers.utils';
+
+describe('timers utils', () => {
+  it('should exist', () => {
+    expect(timersUtils).toBeDefined();
+  });
+
+  describe('createNewTimer', () => {
+    it('should work', () => {
+      expect(timersUtils.createNewTimer({ ms: 1, text: 'foo' }, 2)).toEqual({
+        ms: 3,
+        text: 'foo',
+      });
+    });
+  });
+
+  describe('insertTimer', () => {
+    it('should work when there are no existing timers', () => {
+      expect(timersUtils.insertTimer([], { ms: 1, text: 'foo' })).toEqual([
+        { ms: 1, text: 'foo' },
+      ]);
+    });
+
+    it('should work when there are existing timers', () => {
+      expect(timersUtils.insertTimer([
+        { ms: 1, text: 'foo' },
+        { ms: 3, text: 'foo' },
+      ],
+      { ms: 2, text: 'foo' },
+      )).toEqual([
+        { ms: 1, text: 'foo' },
+        { ms: 2, text: 'foo' },
+        { ms: 3, text: 'foo' },
+      ]);
+    });
+  });
+});

--- a/src/utils/local-storage/local-storage.js
+++ b/src/utils/local-storage/local-storage.js
@@ -1,4 +1,5 @@
 // @flow
+import { get } from 'lodash';
 import config from '../../config';
 
 export function parseLocalStorageData(data: ?string) {
@@ -44,16 +45,25 @@ export function getInitialHistoryStateFromLocalStorage() {
     if (localStorageData && localStorageData.history && Array.isArray(localStorageData.history)) {
       return Object.assign({}, historyState, {
         time: localStorageData.history,
+        timers: [],
       });
     }
 
     // old localStorageData structure does not exist.
-    // return localStorageData if it exists, else start over at [0]
+    // check if localStorageData exists
     if (localStorageData) {
-      return localStorageData.history || { time: [0] };
+      // validate data on localStorageData and provide intialize where necessary
+      // return localStorageData.history || { time: [0] };
+      return {
+        time: get(localStorageData, 'history.time', [0]),
+        timers: get(localStorageData, 'history.timers', []),
+      };
     }
   }
 
-  // no initial history exists so we initialize at [0]
-  return { time: [0] };
+  // no initial history exists so we initialize it
+  return {
+    time: [0],
+    timers: [],
+  };
 }

--- a/src/utils/local-storage/local-storage.test.js
+++ b/src/utils/local-storage/local-storage.test.js
@@ -78,18 +78,36 @@ describe('localStorage utils', () => {
       it('should work', () => {
         expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({
           time: [0],
+          timers: [],
         });
       });
     });
 
     describe('when correct data structure exists', () => {
       beforeEach(() => {
-        localStorage.setItem('agletTimekeeper', JSON.stringify({ history: { time: [1] } }));
+        localStorage.setItem('agletTimekeeper', JSON.stringify(
+          {
+            history: {
+              time: [1],
+              timers: [
+                {
+                  time: 1,
+                  text: 'foo',
+                },
+              ],
+            },
+          }));
       });
 
       it('should work', () => {
         expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({
           time: [1],
+          timers: [
+            {
+              time: 1,
+              text: 'foo',
+            },
+          ],
         });
       });
     });
@@ -100,7 +118,7 @@ describe('localStorage utils', () => {
       });
 
       it('should work', () => {
-        expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({ time: [0] });
+        expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({ time: [0], timers: [] });
       });
     });
 
@@ -110,7 +128,7 @@ describe('localStorage utils', () => {
       });
 
       it('should work', () => {
-        expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({ time: [0] });
+        expect(utils.getInitialHistoryStateFromLocalStorage()).toEqual({ time: [0], timers: [] });
       });
     });
   });


### PR DESCRIPTION
## Description
- add timers to history
- add timers utils to share modular code
- add setTimers action for bootstrapping the app
- update local-storage utils to account for timers in local storage

## Related Issue
#5 

## Motivation and Context
- Timers that are added by a user should persist on refresh

## Screenshots (if appropriate):

## Types of changes
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Style change (non-breaking change that adds no functionality or fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added a screenshot if appropriate.
- Tested in
- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
