### PR TITLE
Timers layout

### DIFF
--- a/src/components/timers/timers.component.js
+++ b/src/components/timers/timers.component.js
@@ -4,8 +4,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import prettyMs from 'pretty-ms';
-import { parseTimer } from '../../utils/timers-parser/timers-parser.utils';
+import { find } from 'lodash';
 
+import { parseTimer } from '../../utils/timers-parser/timers-parser.utils';
 import style from './timers.component.style.scss';
 
 type Props = {
@@ -102,41 +103,46 @@ class Timers extends Component<Props, State> {
       </div>
     ));
 
-    const inactiveTimersToRender = this.props.timersState.expired.map(timer => (
-      <div
-        key={`${timer.ms}${timer.text}`}
-        className={style.timer}
-      >
-        <span
-          className={style.time}
-        >{prettyMs(ms - timer.ms)}</span> <span className={style.adverb}>ago: </span>
-        <span className={style.text}>{timer.text}</span>
+    const inactiveTimersToRender = this.props.timersState.expired.map((timer) => {
+      let timerClasses = style.timer;
+      if (find(this.props.timersState.recentlyExpired, { ...timer })) {
+        timerClasses += ` ${style.alert}`;
+      }
+
+      return (
+        <div
+          key={`${timer.ms}${timer.text}`}
+          className={timerClasses}
+        >
+          <span
+            className={style.time}
+          >{prettyMs(ms - timer.ms)}</span> <span className={style.adverb}>ago: </span>
+          <span className={style.text}>{timer.text}</span>
+        </div>
+      );
+    });
+
+    const activeTimersBlock = (
+      <div>
+        <div className={style.header}>ACTIVE</div>
+        <div className={style.list}>
+          {activeTimersToRender.length
+            ? activeTimersToRender
+            : <div>No active timers</div>}
+        </div>
       </div>
-    ));
+    );
 
-    let activeTimersBlock;
-    if (activeTimersToRender.length) {
-      activeTimersBlock = (
-        <div>
-          <div className={style.header}>ACTIVE</div>
-          <div className={style.list}>
-            {activeTimersToRender}
-          </div>
+    const inactiveTimersBlock = (
+      <div>
+        <div className={style.header}>EXPIRED</div>
+        <div className={style.list}>
+          {inactiveTimersToRender.length
+            ? inactiveTimersToRender
+            : <div>No expired timers</div>}
         </div>
-      );
-    }
-
-    let inactiveTimersBlock;
-    if (inactiveTimersToRender.length) {
-      inactiveTimersBlock = (
-        <div>
-          <div className={style.header}>EXPIRED</div>
-          <div className={style.list}>
-            {inactiveTimersToRender}
-          </div>
-        </div>
-      );
-    }
+      </div>
+    );
 
     let alertsToRender;
     if (this.props.timersState.recentlyExpired.length) {
@@ -160,6 +166,7 @@ class Timers extends Component<Props, State> {
       );
     }
 
+
     return (
       <div className={style.container}>
         {alertsBlock}
@@ -171,7 +178,6 @@ class Timers extends Component<Props, State> {
             onClick={this.handleSubmit}
           >SUBMIT</button>
         </div>
-
         <form onSubmit={this.handleSubmit}>
           <input
             className={inputClasses}

--- a/src/components/timers/timers.component.style.scss
+++ b/src/components/timers/timers.component.style.scss
@@ -47,14 +47,38 @@
 
 .header {
   margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid $swatch01;
 }
 
 .list {
   margin-bottom: 24px;
 }
 
+.timers {
+  .alert {
+    color: $swatch01;
+    animation: none;
+  }
+
+  @media (min-width: 500px) {
+    display: flex;
+    justify-content: space-between;
+    animation: fadeIn 300ms ease;
+
+    & > div {
+      width: calc(50% - 10px);
+    }
+
+    .alert {
+      color: $swatch08;
+    }
+  }
+}
+
 .timer {
   margin-bottom: 8px;
+  transition: color 300ms ease;
 }
 
 .adverb {
@@ -71,10 +95,25 @@
 }
 
 .alerts {
-  margin-bottom: 24px;
+  display: block;
+
+  @media (min-width: 500px) {
+    display: none;
+  }
 }
 
 .alert {
   margin-bottom: 8px;
   color: $swatch08;
+  animation: fadeIn 300ms ease;
+}
+
+@keyframes fadeIn {
+  0% {
+    color: $swatch01;
+  }
+
+  100% {
+    color: $swatch08;
+  }
 }

--- a/src/components/timers/timers.component.style.scss
+++ b/src/components/timers/timers.component.style.scss
@@ -64,7 +64,6 @@
   @media (min-width: 500px) {
     display: flex;
     justify-content: space-between;
-    animation: fadeIn 300ms ease;
 
     & > div {
       width: calc(50% - 10px);
@@ -72,6 +71,7 @@
 
     .alert {
       color: $swatch08;
+      animation: fadeIn 300ms ease;
     }
   }
 }

--- a/src/containers/app/app.container.style.scss
+++ b/src/containers/app/app.container.style.scss
@@ -40,7 +40,7 @@ $scaled-large: $size * ($large * 0.01);
 
 .timers {
   padding: 24px;
-  max-width: 320px;
+  max-width: 660px;
   margin: 0 auto;
   border-top: 1px solid $swatch01;
 }


### PR DESCRIPTION
## Description
- make timers two columns on screens over 500px
- when timers are two columns hide alerts and highlight the recently expired timers in the expired timers column
- add animations for timers as they pop in

## Related Issue
#5 

## Motivation and Context
- makes it easier to differentiate between active and expired timers as well recognized recently expired timers with minimal layout change

## Screenshots (if appropriate):

<img width="682" alt="screen shot 2017-10-24 at 6 53 03 am" src="https://user-images.githubusercontent.com/925980/31941610-0f7a0074-b888-11e7-8e56-c0cba1dc94c0.png">

## Types of changes
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Style change (non-breaking change that adds no functionality or fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added a screenshot if appropriate.
- Tested in
- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
